### PR TITLE
Update GitHub Actions to clear Node 20 deprecations

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Setup Poetry cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ~/.local
         key: poetry-${{ inputs.poetry_version }}
@@ -25,7 +25,7 @@ runs:
       with:
         version: ${{ inputs.poetry_version }}
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         cache: poetry
         python-version: ${{ inputs.python_version }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,12 +16,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           git_user_signingkey: true
@@ -35,7 +35,7 @@ jobs:
       - name: Format
         run: make format
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Run format
           commit_user_name: ${{ secrets.GIT_USER_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           lfs: true
       - name: Setup
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Publish

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           lfs: true
@@ -34,7 +34,7 @@ jobs:
           git config user.name "$GIT_USER_NAME"
           git config user.email "$GIT_USER_EMAIL"
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           git_user_signingkey: true


### PR DESCRIPTION
- actions/checkout v3 -> v5
- crazy-max/ghaction-import-gpg v5 -> v7
- stefanzweifel/git-auto-commit-action v4 -> v7
- actions/cache v3 -> v5, actions/setup-python v4 -> v6 (inside local .github/actions/setup)

snok/install-poetry (composite) is not affected by the Node 20 deprecation, so left as-is.