### PR TITLE
docs: enrich csgo-dsdk README with API, pipeline role, and PII scrubber deep dive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,127 @@ Python Data Science Development Kit for CS:GO.
 Description
 -----------
 
-Do data science with CS:GO.
+``pureskillgg-csgo-dsdk`` is a small, CS:GO/CS2-specific data-science library,
+layered on top of the generic `pureskillgg-dsdk`_ package, that provides utility
+functions to clean up and anonymize **CSDS** ("Counter-Strike Data Standard")
+match data before analysis or publication.
+
+It is an importable toolkit, not a running service: there are no lambdas, no
+``serverless.yml``, no Step Functions, no Terraform, and no CLI commands. It
+ships zero deployed AWS infrastructure. The package is consumed by downstream
+data-science and analytics repos that read parsed match data and need to strip
+personally identifiable information (PII) or remove overtime rounds first.
+
+.. _pureskillgg-dsdk: https://pypi.python.org/pypi/pureskillgg-dsdk
+
+What it does
+~~~~~~~~~~~~
+
+The package (``pureskillgg_csgo_dsdk``) exposes exactly four public symbols from
+its top-level ``__init__``:
+
+- ``scrub_csds_pii`` - anonymize a CSDS match (manifest + per-channel
+  DataFrames) in place.
+- ``pop_overtime`` - remove rows for rounds past regular time from a channel
+  DataFrame.
+- ``SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS`` - a constant list of the CSDS channels
+  a caller should load before scrubbing.
+- ``MissingColumns`` / ``UnsupportedChannelStructure`` - exceptions raised when a
+  DataFrame lacks a required column.
+
+The **scrubber** (``scrubber/scrub_pii.py``) rewrites a CSDS match in place. In
+the manifest it replaces ``jobId`` with the anonymous ``id`` everywhere (via a
+``rapidjson`` dump / string-replace / load round-trip), redacts ``sharecode``,
+``demoId`` and ``metadata.bucket``, and lowers ``matchDate`` precision to
+minutes. In the channel DataFrames it redacts identifying columns (``sharecode``
+and ``demo_id`` in ``header``; ``name_new`` / ``name_old`` in ``player_name``;
+``name`` / ``clan_tag`` in ``player_personal``), maps each unique ``steam_id`` to
+a letter (``A``, ``B``, ``C`` ...), zeroes ``ping`` in ``player_status``, and
+caps inflated ``player_info`` stats (``wins`` over 2500 to 2501; each of
+``commends_friendly`` / ``commends_leader`` / ``commends_teacher`` over 100 to
+101). Every mutation also tags the corresponding manifest column ``origin`` with
+``-redacted`` or ``-capped`` and flips that channel's ``redacted`` flag.
+
+The **overtime filter** (``overtime/pop_overtime.py``) drops rows whose
+``round`` exceeds ``max_rounds_csgo`` (default ``30``) from any channel DataFrame
+that has a ``round`` column, mutating the input in place and returning the
+removed overtime rows. It raises ``MissingColumns`` if there is no ``round``
+column. There is no automatic short-match detection; a caller may pass
+``max_rounds_csgo=16`` manually for short matches.
+
+For a field-by-field breakdown of the scrubber's redact-vs-cap rules and its
+manifest bookkeeping, see the deep dive linked under `Documentation`_.
+
+Pipeline role
+~~~~~~~~~~~~~
+
+This is a downstream-consumed helper library, not a stage in the match
+pipeline. It operates on CSDS channel data - the per-match DataFrames plus
+manifest produced upstream by the demo replay / CSDS parsing stage
+(``csgo-rushb`` / csds).
+
+Data-science and analytics code imports it to anonymize match data before it
+leaves the platform and to strip overtime rounds before modeling. Consumers
+include ``csgo-datascience``, the coach / PPP / match-conversion pipeline
+(``csgo-ppp``, ``csgo-coach``, ``csgo-progression``), and dataset-export /
+Data-Exchange tooling. Any actual AWS I/O (reading the parsed match DataFrames
+from S3) is performed by those consuming repos through ``pureskillgg-dsdk``
+readers/loaders, not here.
+
+Public API
+~~~~~~~~~~
+
+These are the confirmed exported symbols. They are the library's only "jobs";
+this package owns no AWS resources, queues, tables, or log groups.
+
+- ``scrub_csds_pii(manifest, data)`` - anonymize a CSDS match in place. Replaces
+  ``jobId`` with the anonymous ``id`` throughout the manifest, redacts
+  ``sharecode`` / ``demoId`` / ``metadata.bucket``, lowers ``matchDate`` to
+  minute precision, redacts the identifying name/clan/sharecode/demo columns,
+  maps ``steam_id`` values to letters, zeroes pings, caps inflated wins/commends,
+  and flags every affected manifest channel/column as redacted or capped.
+  Returns the (rewritten) manifest; the ``data`` dict is mutated in place.
+- ``pop_overtime(df, *, max_rounds_csgo=30)`` - remove rows for rounds past
+  regular time from a channel DataFrame (in place) and return the removed
+  overtime rows. Raises ``MissingColumns`` if there is no ``round`` column.
+- ``SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS`` - list of channel descriptors
+  (``player_name``, ``header``, ``player_personal``, ``player_info``,
+  ``player_status``) telling callers which CSDS channels to load before running
+  ``scrub_csds_pii``.
+- ``MissingColumns`` / ``UnsupportedChannelStructure`` - error types signaling a
+  DataFrame lacks a required column. ``MissingColumns`` subclasses
+  ``UnsupportedChannelStructure`` and carries the offending column names on its
+  ``columns`` attribute.
+
+Logs and observability
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This is a pure Python library and owns **no** cloud resources, so there is
+nothing to find in CloudWatch. It has no AWS-SDK calls, no DynamoDB / SQS / SNS /
+S3 / Lambda / Step Functions usage, no DLQs, no Sentry integration, and no
+``LOG_LEVEL`` handling. (The only ``bucket`` token in the code overwrites the
+manifest's ``metadata.bucket`` field with the literal string ``redacted`` during
+scrubbing - it is not a real S3 bucket reference.)
+
+- **Runtime behavior:** failures surface only as raised Python exceptions
+  (``MissingColumns`` / ``UnsupportedChannelStructure`` from this library, plus a
+  ``RuntimeError`` if a manifest channel or column referenced during scrubbing is
+  missing) propagated to whatever process imports the library. To find the logs
+  for a real match run, look at the **consuming service** (for example
+  ``csgo-datascience`` or the PPP/coach pipeline), not at this repo.
+- **CI/CD:** the only observable surface owned by this repo is GitHub Actions
+  (``main`` test, ``format``, ``publish`` to PyPI, ``version`` git-tag trigger).
+  Failures show up as red GitHub Actions runs, not CloudWatch.
+
+Documentation
+~~~~~~~~~~~~~
+
+- `docs/scrub-csds-pii.md <docs/scrub-csds-pii.md>`_ - deep dive on
+  ``scrub_csds_pii``: the exact fields redacted vs. capped, the
+  ``steam_id`` -> letter mapping, the ``jobId`` -> ``id`` manifest round-trip,
+  and the manifest channel/column bookkeeping. This is the privacy-critical path
+  for any data leaving the platform (for example Data Exchange / academic
+  datasets), so the precise rules are worth knowing before relying on it.
 
 Installation
 ------------

--- a/docs/scrub-csds-pii.md
+++ b/docs/scrub-csds-pii.md
@@ -1,0 +1,86 @@
+# Deep dive: `scrub_csds_pii`
+
+`scrub_csds_pii(manifest, data)` anonymizes a single CSDS ("Counter-Strike Data
+Standard") match in place. It is the privacy-critical path for any data leaving
+the platform (for example Data Exchange / academic datasets), so this document
+spells out exactly which fields are **redacted** (overwritten with a constant)
+vs. **capped** (clamped to a ceiling), and how the manifest bookkeeping works.
+
+Source: `pureskillgg_csgo_dsdk/scrubber/scrub_pii.py`.
+
+## Inputs and return value
+
+- `manifest` (dict): the CSDS manifest. The function returns a **rewritten**
+  manifest (because of the `jobId` round-trip described below), so callers must
+  use the return value.
+- `data` (dict): a mapping of channel name to a pandas DataFrame. This is
+  mutated **in place** and is not returned.
+
+Before calling, load the channels listed in
+`SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS`: `player_name`, `header`,
+`player_personal`, `player_info`, `player_status`.
+
+## What happens to the manifest
+
+1. **`jobId` -> `id` round-trip.** `replace_job_id` reads `manifest["jobId"]`
+   and `manifest["id"]` (the anonymous id), serializes the whole manifest with
+   `rapidjson.dumps`, does a plain string `.replace(job_id, anon_id)`, then
+   `rapidjson.loads` it back. This removes the job id *everywhere it appears* in
+   the manifest, not just the top-level key. It also sets
+   `manifest["redacted"] = True`.
+2. **Constant redactions.** `manifest["sharecode"]`, `manifest["demoId"]`, and
+   `manifest["metadata"]["bucket"]` are overwritten with the literal string
+   `"redacted"`. (The `bucket` here is a manifest field, not a live S3 bucket.)
+3. **Date precision.** `manifest["matchDate"]` is reparsed and re-emitted at
+   minute precision (`fix_date_precision`, `timespec="minutes"`, hardcoded at the
+   call site — there is no public way to change the precision).
+4. **Channel `redacted` flags initialized.** Every channel's `redacted` flag is
+   first set to `False`; per-column edits below then flip the applicable ones
+   back to `True`.
+
+## What happens to the channel DataFrames
+
+Columns are redacted only **if they exist** (`replace_if_exists`), so a match
+missing a channel/column is skipped rather than erroring.
+
+| Channel | Column(s) | Action |
+| --- | --- | --- |
+| `header` | `sharecode`, `demo_id` | overwritten with `"redacted"` |
+| `player_name` | `name_new`, `name_old` | overwritten with `"redacted"` |
+| `player_personal` | `name`, `clan_tag` | overwritten with `"redacted"` |
+| `player_personal` | `steam_id` | mapped to letters `A`, `B`, `C` ... |
+| `player_status` | `ping` | set to `0` |
+| `player_info` | `wins` | values over 2500 clamped to 2501 (capped) |
+| `player_info` | `commends_friendly`, `commends_leader`, `commends_teacher` | values over 100 clamped to 101 (capped) |
+
+Note that player names live under `name_new` / `name_old` in the `player_name`
+channel and under `name` in `player_personal` — there is no single `name`
+column covering all of them.
+
+### `steam_id` letter mapping
+
+`fix_steam_ids` builds a dict from each unique `steam_id` in `player_personal`
+to a 26-letter alphabet (`A` .. `Z`) and applies it. A match with more than 26
+unique steam ids would raise `IndexError` — a theoretical edge, not an observed
+issue.
+
+## Manifest origin/comment bookkeeping
+
+Every mutation also records what it did in the manifest:
+
+- **Redacted columns** have `"-redacted"` appended to their `origin` string, and
+  their channel's `redacted` flag set to `True`.
+- **Capped columns** (`wins` and the three `commends_*`) have `"-capped"`
+  appended to `origin`, get `" Capped to <value>."` appended to their `comment`,
+  and their channel's `redacted` flag set to `True`.
+
+The channel/column positions are resolved by `get_manifest_indexes`, which
+raises a `RuntimeError` if a referenced channel or column is not present in the
+manifest.
+
+## Errors
+
+- `RuntimeError` — a channel or column referenced during scrubbing is missing
+  from the manifest structure.
+- The library's own `MissingColumns` / `UnsupportedChannelStructure` are raised
+  by the sibling `pop_overtime` helper, not by `scrub_csds_pii`.


### PR DESCRIPTION
## Summary

Expands the thin `README.rst` for `csgo-dsdk` (the CS:GO/CS2-specific data SDK, PyPI package `pureskillgg-csgo-dsdk`) while keeping it valid reStructuredText and preserving every existing badge and boilerplate section verbatim.

### README.rst changes

- Replaces the one-line "Do data science with CS:GO." description with concrete sections:
  - **Description** + **What it does** — the four exported symbols and the actual behavior of the scrubber and overtime filter.
  - **Pipeline role** — a downstream-consumed helper library layered on `pureskillgg-dsdk`, operating on upstream CSDS match data, imported by `csgo-datascience`, the PPP/coach/progression pipeline, and Data-Exchange tooling.
  - **Public API** — the confirmed exported functions/constant/exceptions by their real names.
  - **Logs and observability** — explicitly notes this is a pure library with zero cloud resources; runtime failures are raised Python exceptions surfaced in the consuming service, and the only owned observable surface is GitHub Actions (not CloudWatch).
  - **Documentation** — links the new deep dive.
- Keeps Installation, Development and Testing, Publishing, GitHub Actions secrets, Contributing, License, and Warranty unchanged.

### New docs

- `docs/scrub-csds-pii.md` — deep dive on `scrub_csds_pii`: the exact redact-vs-cap rules per channel/column, the `steam_id` -> letter mapping, the `jobId` -> `id` manifest round-trip, and the manifest origin/comment bookkeeping.

All facts were verified against the source (`scrubber/scrub_pii.py`, `overtime/pop_overtime.py`, `errors/channel_structure.py`, `__init__.py`) and `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)