### PR TITLE
Scrub player_chat.text and cap rank_update.win_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## 3.1.0
+## 3.1.0 / 2026-07-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.1.0
+
+### Added
+
+- Scrub `player_chat.text` and cap `rank_update.win_count`, the two new rushb
+  channels carrying PII. `win_count` is the same quantity as `player_info.wins`,
+  already capped at 2501; both now read one shared constant.
+- `csds_pii_channel_instructions(manifest)` returns only the PII channels a CSDS
+  actually has. `get_channels` raises on a channel missing from the manifest, so
+  callers must filter or adding a channel breaks every older CSDS.
+
 ## 3.0.1 / 2026-06-14
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ personally identifiable information (PII) or remove overtime rounds first.
 What it does
 ~~~~~~~~~~~~
 
-The package (``pureskillgg_csgo_dsdk``) exposes exactly four public symbols from
+The package (``pureskillgg_csgo_dsdk``) exposes exactly five public symbols from
 its top-level ``__init__``:
 
 - ``scrub_csds_pii`` - anonymize a CSDS match (manifest + per-channel
@@ -40,6 +40,8 @@ its top-level ``__init__``:
   DataFrame.
 - ``SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS`` - a constant list of the CSDS channels
   a caller should load before scrubbing.
+- ``csds_pii_channel_instructions`` - that list filtered to the channels a given
+  manifest actually has. Load through this, not the raw constant.
 - ``MissingColumns`` / ``UnsupportedChannelStructure`` - exceptions raised when a
   DataFrame lacks a required column.
 
@@ -50,8 +52,10 @@ the manifest it replaces ``jobId`` with the anonymous ``id`` everywhere (via a
 minutes. In the channel DataFrames it redacts identifying columns (``sharecode``
 and ``demo_id`` in ``header``; ``name_new`` / ``name_old`` in ``player_name``;
 ``name`` / ``clan_tag`` in ``player_personal``), maps each unique ``steam_id`` to
-a letter (``A``, ``B``, ``C`` ...), zeroes ``ping`` in ``player_status``, and
-caps inflated ``player_info`` stats (``wins`` over 2500 to 2501; each of
+a letter (``A``, ``B``, ``C`` ...), zeroes ``ping`` in ``player_status``,
+redacts ``text`` in ``player_chat``, and caps inflated stats (``player_info``
+``wins`` and ``rank_update`` ``win_count`` — the same quantity — over 2500 to
+2501; each of
 ``commends_friendly`` / ``commends_leader`` / ``commends_teacher`` over 100 to
 101). Every mutation also tags the corresponding manifest column ``origin`` with
 ``-redacted`` or ``-capped`` and flips that channel's ``redacted`` flag.
@@ -100,8 +104,15 @@ this package owns no AWS resources, queues, tables, or log groups.
   overtime rows. Raises ``MissingColumns`` if there is no ``round`` column.
 - ``SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS`` - list of channel descriptors
   (``player_name``, ``header``, ``player_personal``, ``player_info``,
-  ``player_status``) telling callers which CSDS channels to load before running
-  ``scrub_csds_pii``.
+  ``player_status``, ``player_chat``, ``rank_update``) telling callers which CSDS
+  channels to load before running ``scrub_csds_pii``.
+- ``csds_pii_channel_instructions(manifest)`` - the same list, filtered to the
+  channels present in ``manifest``. ``get_channels`` raises on a channel missing
+  from the manifest, so a CSDS written before a channel existed fails if the raw
+  constant is passed through; filter with this instead::
+
+    data = loader.get_channels(csds_pii_channel_instructions(loader.manifest))
+    manifest = scrub_csds_pii(loader.manifest, data)
 - ``MissingColumns`` / ``UnsupportedChannelStructure`` - error types signaling a
   DataFrame lacks a required column. ``MissingColumns`` subclasses
   ``UnsupportedChannelStructure`` and carries the offending column names on its

--- a/docs/scrub-csds-pii.md
+++ b/docs/scrub-csds-pii.md
@@ -16,9 +16,22 @@ Source: `pureskillgg_csgo_dsdk/scrubber/scrub_pii.py`.
 - `data` (dict): a mapping of channel name to a pandas DataFrame. This is
   mutated **in place** and is not returned.
 
-Before calling, load the channels listed in
-`SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS`: `player_name`, `header`,
-`player_personal`, `player_info`, `player_status`.
+Before calling, load the PII channels. **Filter the instruction list against
+the manifest first** — `get_channels` raises on a channel missing from the
+manifest, and a CSDS written before a channel existed does not carry it:
+
+```python
+from pureskillgg_csgo_dsdk import csds_pii_channel_instructions, scrub_csds_pii
+
+data = loader.get_channels(csds_pii_channel_instructions(loader.manifest))
+manifest = scrub_csds_pii(loader.manifest, data)
+```
+
+Passing `SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS` to `get_channels` unfiltered works
+only while every listed channel happens to be present, and breaks whenever a
+channel is added to the list. The list is `player_name`, `header`,
+`player_personal`, `player_info`, `player_status`, `player_chat`,
+`rank_update`.
 
 ## What happens to the manifest
 
@@ -50,12 +63,19 @@ missing a channel/column is skipped rather than erroring.
 | `player_personal` | `name`, `clan_tag` | overwritten with `"redacted"` |
 | `player_personal` | `steam_id` | mapped to letters `A`, `B`, `C` ... |
 | `player_status` | `ping` | set to `0` |
+| `player_chat` | `text` | overwritten with `"redacted"` |
 | `player_info` | `wins` | values over 2500 clamped to 2501 (capped) |
+| `rank_update` | `win_count` | values over 2500 clamped to 2501 (capped) |
 | `player_info` | `commends_friendly`, `commends_leader`, `commends_teacher` | values over 100 clamped to 101 (capped) |
 
 Note that player names live under `name_new` / `name_old` in the `player_name`
 channel and under `name` in `player_personal` — there is no single `name`
 column covering all of them.
+
+`player_info.wins` and `rank_update.win_count` are the same quantity, so they
+share one cap (`WINS_CAP_THRESHOLD` / `WINS_CAP_VALUE`). Capping one without the
+other would leak around the rule. Only `text` is removed from `player_chat`:
+who spoke and when is kept.
 
 ### `steam_id` letter mapping
 

--- a/pureskillgg_csgo_dsdk/__init__.py
+++ b/pureskillgg_csgo_dsdk/__init__.py
@@ -2,7 +2,11 @@
 PureSkill.gg CS:GO Data Science Development Kit.
 """
 
-from .scrubber import scrub_csds_pii, SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS
+from .scrubber import (
+    scrub_csds_pii,
+    SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS,
+    csds_pii_channel_instructions,
+)
 from .overtime import pop_overtime
 from .errors import MissingColumns
 from .errors import UnsupportedChannelStructure

--- a/pureskillgg_csgo_dsdk/scrubber/__init__.py
+++ b/pureskillgg_csgo_dsdk/scrubber/__init__.py
@@ -2,4 +2,8 @@
 Scrub PII from your data
 """
 
-from .scrub_pii import scrub_csds_pii, SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS
+from .scrub_pii import (
+    scrub_csds_pii,
+    SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS,
+    csds_pii_channel_instructions,
+)

--- a/pureskillgg_csgo_dsdk/scrubber/scrub_pii.py
+++ b/pureskillgg_csgo_dsdk/scrubber/scrub_pii.py
@@ -18,7 +18,27 @@ SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS = [
     {"channel": "player_personal"},
     {"channel": "player_info"},
     {"channel": "player_status"},
+    {"channel": "player_chat"},
+    {"channel": "rank_update"},
 ]
+
+WINS_CAP_THRESHOLD = 2500
+WINS_CAP_VALUE = 2501
+
+
+def csds_pii_channel_instructions(manifest: Dict):
+    """Reading instructions for the PII channels this CSDS actually has.
+
+    A CSDS written before a channel existed does not carry it, and get_channels
+    raises on a channel missing from the manifest. Filter with this before
+    loading, or adding a channel here breaks every older CSDS.
+    """
+    available = {channel["channel"] for channel in manifest["channels"]}
+    return [
+        instruction
+        for instruction in SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS
+        if instruction["channel"] in available
+    ]
 
 
 def scrub_csds_pii(manifest: Dict, data: Dict):
@@ -56,6 +76,10 @@ def scrub_csds_pii(manifest: Dict, data: Dict):
 
     replace_if_exists(data, manifest, "player_status", "ping", replacement=0)
 
+    replace_if_exists(data, manifest, "player_chat", "text")
+
+    cap_wins_like(data, manifest, "rank_update", "win_count")
+
     return manifest
 
 
@@ -78,6 +102,25 @@ def replace_if_exists(
             "origin"
         ] += "-redacted"
         manifest["channels"][channel_index]["redacted"] = True
+
+
+def cap_wins_like(data, manifest, channel, column):
+    """Cap a competitive-wins column so a high value cannot single a player out
+
+    The cap is not a parameter: player_info.wins and rank_update.win_count are
+    the same quantity, and one capped while the other is not leaks round it.
+    """
+    if not data_exists(data, channel, column):
+        return
+    df = data[channel]
+    df.loc[df[column] > WINS_CAP_THRESHOLD, column] = WINS_CAP_VALUE
+    data[channel] = df
+    channel_index, column_index = get_manifest_indexes(manifest, channel, column)
+    manifest["channels"][channel_index]["columns"][column_index]["origin"] += "-capped"
+    manifest["channels"][channel_index]["columns"][column_index][
+        "comment"
+    ] += f" Capped to {WINS_CAP_VALUE}."
+    manifest["channels"][channel_index]["redacted"] = True
 
 
 def get_manifest_indexes(manifest, channel, column):
@@ -140,9 +183,9 @@ def fix_commends_and_wins(data, manifest):
     pi = data["player_info"]
     columns = pi.columns
     if "wins" in columns:
-        index = pi["wins"] > 2500
-        pi.loc[index, "wins"] = 2501
-        cap_manifest_to_value("wins", value=2501)
+        index = pi["wins"] > WINS_CAP_THRESHOLD
+        pi.loc[index, "wins"] = WINS_CAP_VALUE
+        cap_manifest_to_value("wins", value=WINS_CAP_VALUE)
     if "commends_friendly" in columns:
         index = pi["commends_friendly"] > 100
         pi.loc[index, "commends_friendly"] = 101

--- a/pureskillgg_csgo_dsdk/scrubber/scrub_pii.py
+++ b/pureskillgg_csgo_dsdk/scrubber/scrub_pii.py
@@ -108,7 +108,7 @@ def cap_wins_like(data, manifest, channel, column):
     """Cap a competitive-wins column so a high value cannot single a player out
 
     The cap is not a parameter: player_info.wins and rank_update.win_count are
-    the same quantity, and one capped while the other is not leaks round it.
+    the same quantity, and one capped while the other is not leaks around it.
     """
     if not data_exists(data, channel, column):
         return

--- a/pureskillgg_csgo_dsdk/scrubber/scrub_pii_test.py
+++ b/pureskillgg_csgo_dsdk/scrubber/scrub_pii_test.py
@@ -3,11 +3,17 @@
 
 import copy
 import os
+import pandas as pd
 import pytest
 import dateutil.parser
 from pureskillgg_dsdk import GameDsLoader, DsReaderFs
 
-from .scrub_pii import scrub_csds_pii, SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS
+from .scrub_pii import (
+    scrub_csds_pii,
+    SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS,
+    csds_pii_channel_instructions,
+    WINS_CAP_VALUE,
+)
 
 
 def test_remove_pii():
@@ -20,7 +26,8 @@ def test_remove_pii():
         log=None,
     )
     csds_loader = GameDsLoader(reader=csds_reader, log=None)
-    data = csds_loader.get_channels(SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS)
+    instructions = csds_pii_channel_instructions(csds_loader.manifest)
+    data = csds_loader.get_channels(instructions)
     data["player_info"]["commends_teacher"] = 12345
     manifest = copy.deepcopy(csds_loader.manifest)
 
@@ -41,10 +48,92 @@ def test_remove_pii():
     date = dateutil.parser.isoparse(manifest["matchDate"])
     assert date.second == 0
 
-    scrubbed_channels = [k["channel"] for k in SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS]
+    scrubbed_channels = [k["channel"] for k in instructions]
     for channel in manifest["channels"]:
         if channel["channel"] in scrubbed_channels:
             assert channel["redacted"] is True
         else:
             assert channel["redacted"] is False
     assert manifest["redacted"] is True
+
+
+def _manifest(*channels):
+    return {
+        "jobId": "job-1",
+        "id": "anon-1",
+        "sharecode": "CSGO-abc",
+        "demoId": "demo-1",
+        "matchDate": "2026-07-30T12:34:56.789Z",
+        "metadata": {"bucket": "a-bucket"},
+        "channels": [
+            {
+                "channel": name,
+                "columns": [
+                    {"name": col, "origin": "replay", "comment": ""} for col in cols
+                ],
+            }
+            for name, cols in channels
+        ],
+    }
+
+
+def test_redacts_chat_text():
+    manifest = _manifest(("player_chat", ["round", "tick", "player_id", "text"]))
+    data = {
+        "player_chat": pd.DataFrame(
+            {"round": [1], "tick": [10], "player_id": [3], "text": ["gg wp add me"]}
+        )
+    }
+
+    manifest = scrub_csds_pii(manifest, data)
+
+    assert list(data["player_chat"]["text"]) == ["redacted"]
+    # who talked and when survives; only the content goes
+    assert list(data["player_chat"]["player_id"]) == [3]
+    chat = manifest["channels"][0]
+    assert chat["redacted"] is True
+    text_col = [c for c in chat["columns"] if c["name"] == "text"][0]
+    assert text_col["origin"].endswith("-redacted")
+
+
+def test_caps_rank_update_win_count_like_player_info_wins():
+    # rank_update.win_count is the same quantity as player_info.wins, which is
+    # already capped -- an uncapped copy in a new channel would leak round it
+    manifest = _manifest(("rank_update", ["round", "tick", "player_id", "win_count"]))
+    data = {
+        "rank_update": pd.DataFrame(
+            {
+                "round": [1, 1],
+                "tick": [10, 11],
+                "player_id": [3, 4],
+                "win_count": [99999, 12],
+            }
+        )
+    }
+
+    manifest = scrub_csds_pii(manifest, data)
+
+    assert list(data["rank_update"]["win_count"]) == [WINS_CAP_VALUE, 12]
+    assert manifest["channels"][0]["redacted"] is True
+
+
+def test_leaves_a_csds_without_the_new_channels_alone():
+    # pre-overhaul CSDS in S3 carry neither channel
+    manifest = _manifest(("header", ["sharecode", "demo_id"]))
+    data = {}
+
+    manifest = scrub_csds_pii(manifest, data)
+
+    assert manifest["redacted"] is True
+
+
+def test_instructions_are_filtered_to_what_the_csds_has():
+    # a CSDS written before player_chat existed must not ask for it: the loader
+    # raises on a channel missing from the manifest
+    old = _manifest(("header", ["sharecode"]), ("player_status", ["ping"]))
+    names = [i["channel"] for i in csds_pii_channel_instructions(old)]
+    assert names == ["header", "player_status"]
+
+    new = _manifest(("player_chat", ["text"]), ("rank_update", ["win_count"]))
+    names = [i["channel"] for i in csds_pii_channel_instructions(new)]
+    assert sorted(names) == ["player_chat", "rank_update"]

--- a/pureskillgg_csgo_dsdk/scrubber/scrub_pii_test.py
+++ b/pureskillgg_csgo_dsdk/scrubber/scrub_pii_test.py
@@ -1,16 +1,13 @@
 # pylint: disable=missing-docstring
-# pylint: disable=unused-import
 
 import copy
 import os
 import pandas as pd
-import pytest
 import dateutil.parser
 from pureskillgg_dsdk import GameDsLoader, DsReaderFs
 
 from .scrub_pii import (
     scrub_csds_pii,
-    SCRUB_CSDS_PII_CHANNEL_INSTRUCTIONS,
     csds_pii_channel_instructions,
     WINS_CAP_VALUE,
 )
@@ -98,7 +95,7 @@ def test_redacts_chat_text():
 
 def test_caps_rank_update_win_count_like_player_info_wins():
     # rank_update.win_count is the same quantity as player_info.wins, which is
-    # already capped -- an uncapped copy in a new channel would leak round it
+    # already capped -- an uncapped copy in a new channel would leak around it
     manifest = _manifest(("rank_update", ["round", "tick", "player_id", "win_count"]))
     data = {
         "rank_update": pd.DataFrame(


### PR DESCRIPTION
Phase 8 of the rushb channel overhaul: the PII side. Gates the ADX path — the scrubber is what stands between raw CSDS and Data Exchange, so this has to land before rushb reaches prod.

## `player_chat.text`

Free-form player-typed content. Redacted, keeping `player_id`, `round` and `tick` — who talked and when is signal; what they typed is not ours to publish.

## `rank_update.win_count` — an existing rule was being routed around

The plan said to "confirm `rank_update` needs none (steam_id already gone)". It needs one. `win_count` is **the same quantity as `player_info.wins`**, which the scrubber already caps at 2501. Verified value for value on a Valve replay, all ten players:

| player | `rank_update.win_count` | `player_info.wins` |
| ---: | ---: | ---: |
| 0 | 22 | 22 |
| 3 | 19 | 19 |
| 8 | 18 | 18 |
| 5 | 10 | 10 |
| 9 | 10 | 10 |
| 2 | 3 | 3 |
| 1 / 6 / 7 | 1 | 1 |
| 4 | 0 | 0 |

So the new channel shipped an uncapped copy of a column we deliberately cap. Now capped by the same rule, and both sites read one shared constant rather than repeating the literals — if they ever disagree that is a bug, so it should not be possible to change one alone.

## Adding to the instruction list is not safe on its own

`get_channels` **raises** `Channel X not found in replay` on a channel missing from the manifest, and `csgo-ppp/scrubber/model.py` passes this constant straight to it. So adding `player_chat` would hard-fail the scrubber on every CSDS written before that channel existed — backfills and reprocessing included.

This is not hypothetical: **adding the channels broke this repo's own `test_remove_pii`**, whose fixture is a 2022 CS:GO-era CSDS. That failure is the production hazard in miniature.

`csds_pii_channel_instructions(manifest)` filters the list to what the CSDS actually has, and is the canonical way to call this. The existing test now uses it.

## Sequencing — this matters

**csgo-ppp [#146](https://github.com/pureskillgg/csgo-ppp/pull/146) must deploy before this releases.** It carries the matching filter inline, since it cannot import the helper until the pin picks up this version. Order:

1. ppp #146 (filter added — a no-op against dsdk 3.0.1, which lists no new channels)
2. this, released to PyPI
3. ppp's `pureskillgg-csgo-dsdk` pin picks it up; `>=3.0.0,<4.0.0` already admits 3.1.0, so no pin change needed

Reversed, the scrubber fails on older CSDS.

## Verification

- 10 tests pass (4 new). `make lint` 10.00/10, unchanged from master. `black` clean.
- New tests cover chat redaction keeping `player_id`, the win-count cap, a CSDS with neither channel, and the instruction filter in both directions.

## Audit of the other new channels

I checked all fifteen new/returning rushb channels' columns for anything identifying. Only these two qualify. `bullet_damage`, `grenade_bounce`, `grenade_vector`, `item_dropped`, `item_refund`, `molotov_fire`, `player_inputs`, `player_sound`, `score_update`, `team_change`, `world_item_vector`, `bot_takeover` and `round_mvp` carry only ids, ticks, positions and game state.

Still open: whether `player_chat` belongs in terraform's `csds_unredacted_channels` for the internal unredacted mirror. That is your call, and terraform runs are billed, so I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
